### PR TITLE
Problem resolved by changing Cycle.all to only access public cycles 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.3-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.3-x86_64-linux)
+      racc (~> 1.4)
     public_suffix (4.0.6)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -242,6 +244,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap

--- a/app/controllers/cycles_controller.rb
+++ b/app/controllers/cycles_controller.rb
@@ -1,5 +1,5 @@
 class CyclesController < ApplicationController
   def index
-    @cycles = Cycle.all
+    @cycles = Cycle.where(public_status: true)
   end
 end


### PR DESCRIPTION
I have changed in the Cycles controller:
Cycle.all to now only show the cycles which have a true public status.

I've tested this by running the app, and now the Cycles which are false no longer show.

I've also added a new cycle with both true and false statuses to test if they are also being displayed properly!